### PR TITLE
Remove dead link to mailinglists.php

### DIFF
--- a/development.php
+++ b/development.php
@@ -118,17 +118,8 @@ include( "top.php" );
             Join #mantisbt IRC
           </a>
 
-          <div class="clearfix"></div>
           <br><br>
 
-          <p>
-            MantisBT developers utilize mailing lists to communicate with other developers, translators, and the community.
-            You may want to join our mailing lists and join the conversation.
-            It is a good idea to discuss larger contributions on the mailing list before getting started.
-          </p>
-          <a type="button" class="btn btn-warning" href="mailinglists.php" onclick="ga('send', 'event', 'Development', 'Browse Mailing Lists');">
-            Browse Mailing Lists
-          </a>
         </div>
       </div>
 


### PR DESCRIPTION
mentioned by a user in IRC
http://mantisbt.org/irclogs/mantisbt/2017/mantisbt.2017-04-20.log.html

mailinglists.php is no longer available since commit
a912eb6783b986e0405580a474de486439662e0d